### PR TITLE
Fix gitignore ignoring Go files that should be checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,15 +111,11 @@ config/private.yml
 
 # Go specific
 /bin/
-/pkg/
 *.o
 *.a
 *.out
-**/vendor/
 Gopkg.lock
 Gopkg.toml
-go.sum
-go.mod
 
 # Binaries for programs and plugins
 *.exe


### PR DESCRIPTION

## Changes proposed in this pull request:

- pkg is a common directory for organizing public code
- vendor, when used, deliberately "vendors" third-party code into the repository; when used, it is intended to be checked in
- go.mod and go.sum are the files necessary for Go Modules, the Go dependency management tool, to work

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None