### PR TITLE
Add a better example CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,13 @@
-* @cloud-gov/cloud-gov-team 
+# Per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+#
+# If you want to match two or more code owners with the same pattern,
+# all the code owners must be on the same line. If the code owners
+# are not on the same line, the pattern matches only the last mentioned
+# code owner.
+
+# EXAMPLES, uncomment to use one
+#* @cloud-gov/platform-ops @cloud-gov/pages-ops @cloud-gov/studio
+#* @cloud-gov/platform-ops @cloud-gov/customer-success-squad 
+#* @cloud-gov/platform-ops @cloud-gov/pages-ops 
+* @cloud-gov/cloud-gov-team
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Also, GitHub no longer marks as invalid


## Security considerations

Safe. These CODEOWNERS are already public.
