### PR TITLE
Remove logo image from profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,3 @@
-<img src="https://cloud.gov/img/SAJKr93fDF-233.svg" alt="cloud.gov logo" width="300">
-
 # Fast, Easy, Secure, and Compliant Cloud Services for U.S. Government Developers
 
 **[Cloud.gov](https://cloud.gov)** is a secure, FedRAMP-authorized Platform as a Service (PaaS) built for U.S. government teams. Deploy, scale, and manage your web apps quickly while meeting strict federal security and compliance standards. Focus on your code and mission—let us handle the heavy lifting.


### PR DESCRIPTION
Removed cloud.gov logo image from README. Link was broken.

## Changes proposed in this pull request:

- Removed broken image link from public readme for Cloud.gov org.
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removes broken image - logo still present as the org icon above the readme.
